### PR TITLE
Ignore `.idea/` directory in `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ phpunit.xml
 composer.lock
 vendor/
 .coverage/
+.idea/


### PR DESCRIPTION
Jetbrains IDEs create and put project-specific files in the `.idea` directory in the root of the repository.

This pull request adds the `.idea/` directory into the repository's top-level `.gitignore` so that the directory is ignored.

Thank you!