### PR TITLE
Add missing fields to PlayerSummary DTO

### DIFF
--- a/src/Data/PlayerSummary.php
+++ b/src/Data/PlayerSummary.php
@@ -22,13 +22,18 @@ final class PlayerSummary extends Data
         public readonly string $avatarfull,
         public readonly string $avatarhash,
         public readonly PersonaState $personastate,
+        public readonly ?int $personastateflags,
         public readonly bool $profilestate = false,
         public readonly ?string $primaryclanid = null,
         #[WithCast(DateTimeInterfaceCast::class, format: 'U')]
         public readonly ?CarbonImmutable $timecreated = null,
+        #[WithCast(DateTimeInterfaceCast::class, format: 'U')]
+        public readonly ?CarbonImmutable $lastlogoff = null,
         public readonly ?string $realname = null,
         public readonly ?string $gameserverip = null,
+        public readonly ?string $gameserversteamid = null,
         public readonly ?string $gameextrainfo = null,
+        public readonly ?int $gameid = null,
         public readonly ?string $loccountrycode = null,
         public readonly ?string $locstatecode = null,
         public readonly ?int $loccityid = null,


### PR DESCRIPTION
Add the following fields from the API response into the DTO:

- personastateflags
- lastlogoff
- gameserversteamid
- gameid